### PR TITLE
Fixed link to samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or install it yourself as:
 
 ## Usage
 
-See [spec/integration/repository_spec.rb](spec/integration/repository_spec.rb) for a sample usage.
+See [spec/integration/gateway_spec.rb](spec/integration/gateway_spec.rb) for a sample usage.
 
 ## Issues
 Issues should be reported in the main ROM repository, [https://github.com/rom-rb/rom/issues](https://github.com/rom-rb/rom/issues)


### PR DESCRIPTION
It looks like the link to spec which should be used as example of API usage is broken.
I've fixed on.