### PR TITLE
Pass the URI directly to `Mongo::Client`

### DIFF
--- a/lib/rom/mongo/gateway.rb
+++ b/lib/rom/mongo/gateway.rb
@@ -12,29 +12,7 @@ module ROM
       attr_reader :collections
 
       def initialize(uri)
-        creds, host_uri = uri.split('@')
-        user, password = creds.split(':')
-
-        if host_uri
-          host, database = host_uri.split('/')
-
-          options = {
-            database: database
-          }
-
-          if user
-            options[:user] = user
-          end
-
-          if password
-            options[:password] = password
-          end
-        else
-          host, database = uri.split('/')
-          options = { database: database }
-        end
-
-        @connection = ::Mongo::Client.new([host], options)
+        @connection = ::Mongo::Client.new(uri)
         @collections = {}
       end
 

--- a/lib/rom/mongo/gateway.rb
+++ b/lib/rom/mongo/gateway.rb
@@ -12,8 +12,29 @@ module ROM
       attr_reader :collections
 
       def initialize(uri)
-        host, database = uri.split('/')
-        @connection = ::Mongo::Client.new([host], database: database)
+        creds, host_uri = uri.split('@')
+        user, password = creds.split(':')
+
+        if host_uri
+          host, database = host_uri.split('/')
+
+          options = {
+            database: database
+          }
+
+          if user
+            options[:user] = user
+          end
+
+          if password
+            options[:password] = password
+          end
+        else
+          host, database = uri.split('/')
+          options = { database: database }
+        end
+
+        @connection = ::Mongo::Client.new([host], options)
         @collections = {}
       end
 

--- a/spec/integration/gateway_spec.rb
+++ b/spec/integration/gateway_spec.rb
@@ -5,7 +5,7 @@ require 'virtus'
 describe 'Mongo gateway' do
   subject(:rom) { setup.finalize }
 
-  let(:setup) { ROM.setup(:mongo, '127.0.0.1:27017/test') }
+  let(:setup) { ROM.setup(:mongo, 'mongodb://127.0.0.1:27017/test') }
   let(:gateway) { rom.gateways[:default] }
 
   after do

--- a/spec/unit/repository_spec.rb
+++ b/spec/unit/repository_spec.rb
@@ -6,6 +6,6 @@ describe ROM::Mongo::Gateway do
   it_behaves_like 'a rom gateway' do
     let(:identifier) { :mongo }
     let(:gateway) { ROM::Mongo::Gateway }
-    let(:uri) { '127.0.0.1:27017/test' }
+    let(:uri) { 'mongodb://127.0.0.1:27017/test' }
   end
 end


### PR DESCRIPTION
There is no need to do any string hacking, the driver knows how to parse the provided URI.